### PR TITLE
bumble edits v1 - make more downstream/low-maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,33 @@ IPFS Working Groups
 
 > Get connected with one of the many working groups that advance IPFS.
 
-Working Groups are regular meetings of people who are collectively working in specific arenas to advance IPFS. Anyone is welcome to join a Working Group and participate so long as they adhere to the [IPFS Community Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md). Browse through the various Working Groups listed below to find one that excites you.
+Working Groups are regular meetings of people who are collectively working in specific arenas to advance IPFS.
+- Anyone is welcome to join a Working Group and participate so long as they adhere to the [IPFS Community Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md). Just show up and jump in anywhere your interests lead.
+- Despite the IPFS ecosystem team's best efforts to maintain this listing, consider it downstream of any working group's own processes and defer to the most recent notes documents in case of conflicting information.
 
 ## Find a Working Group
 
-- [IPFS Implementers](https://github.com/ipfs/ipfs-working-groups/blob/8f20b9a36dbd62722c526c36c1de66c1f2f8e6c7/working-groups/implementers-wg.md)
-- Ecosystem
-- Decentralized Data Compliance
-- Content Routing
-- Network Measurements
-- dApps
-- [Communications](https://github.com/ipfs/ipfs-working-groups/blob/8f20b9a36dbd62722c526c36c1de66c1f2f8e6c7/working-groups/communications-wg.md)
+- IPFS Implementers { [biweekly meetings](https://lu.ma/ipfs-implementers) | [notes](https://pl-strflt.notion.site/IPFS-Implementers-Working-Group-f102a74802b34529a759ffbc3ea20303) | convened by @biglep }
+  - [Implementations](https://docs.ipfs.tech/concepts/ipfs-implementations/), [spec](https://github.com/ipfs/specs) maintenance, IPFS improvement proposals ([IPIPs](https://github.com/ipfs/specs/blob/main/IPIP/0001-lightweight-improvement-proposal-process.md)) current and future, protocol bugs, implementer feedback, user feedback on specific implementations
+- IPFS Ecosystem { internal working group; community calls TBD | convened by @damedoteth }
+  - tracking awesome ipfs development "in the wild" and operating the comms switchboard
+- Decentralized Data Compliance { meetings on a topical/sporadic basis | convened by @bumblefudge }
+  - tracking compliance issues across content-addressed data systems generally; federated/distributed content management; [nopfs](https://github.com/ipfs-shipyard/nopfs) feedback and best practices
+- Content Routing { [monthly meetings](https://lu.ma/ipfs-routing-wg) | [recordings](https://youtube.com/playlist?list=PLuhRWgmPaHtRP5lVouK_eqhC98xaej6Px) | convened by @torfinnolsen }
+  - current topics: HTTP delegated routing, Hydra shutdown impacts, design pathways, options for double hashing CID's
+- Network Measurements { [periodic office hours](https://lu.ma/ipfs-network-measurements) | convened by @yiannisbot & [ProbeLab](https://github.com/plprobelab) }
+  - Network Measurements of decentralized protocols, including but not limited to IPFS, libp2p, etc.
+- IPFS dApps WG { [biweekly meetings](https://lu.ma/ipfs-dapps) | [notes](​https://github.com/ipfs/dapps-wg/) | [telegram group](https://t.me/ipfsdapps) | convened by @adin, @lidel, et al. }
+  - community calls discussing how dapps can use or be entirely hosted on IPFS today and in the future 
+- Communications { TBD }
 
 ## IPFS Adjacent Working Groups
-- [libp2p Implementers](https://github.com/ipfs/ipfs-working-groups/blob/721e226b43b3c9a965ce388cee983d418063d1f1/working-groups/libp2p-implementers-wg.md)
-- [IPLD](https://github.com/ipfs/ipfs-working-groups/blob/fb5db40204c1a2c7bedb7f88c1bc2619b7e9fce1/working-groups/ipld-wg.md)
-- IPVM
-- WNFS
+- `libp2p` Implementers { [meetings](https://calendar.google.com/calendar/u/0/embed?src=libp2p.io_0q9682i3te7eanhe9q7ae1c58g@group.calendar.google.com) | [agendas on-list](https://discuss.libp2p.io/search?q=community%20call%20order%3Alatest) | convened by @p-shahi & @dhuseby }
+  - decentralized network tooling both for and beyond ipfs: community events, roadmap, new features, triage, and performance issues.
+- `ipld` Community Calls { meetings on a sporadic/as-needed basis | [notes](https://github.com/ipld/team-mgmt/tree/master/meeting-notes) | convened by @vmx }
+  - ipld tooling and best practices, schema coordination, multiformats registry governance and IETF hardening
+- IPVM { TBD }
+- WNFS { TBD }
 
 
 ## Contributing

--- a/working-groups/communications-wg.md
+++ b/working-groups/communications-wg.md
@@ -1,3 +1,0 @@
-# IPFS Communications Working Group
-
-Coming soon...

--- a/working-groups/implementers-wg.md
+++ b/working-groups/implementers-wg.md
@@ -1,7 +1,0 @@
-# IPFS Implementers Working Group
-
-Biweekly working group for people who create and maintain different IPFS implementations.
-
-What’s covered: IPFS improvement proposals (IPIPS), protocol bugs, feedback.
-
-[Attend a meeting](https://lu.ma/ipfs-implementers)

--- a/working-groups/ipld-wg.md
+++ b/working-groups/ipld-wg.md
@@ -1,7 +1,0 @@
-# IPLD Working Group
-
-Collaborative community for IPLD (InterPlanetary Linked Data), a data model for the content-addressable web.
-
-What's covered: Developer resourcing needed for new implementations & libraries, standardization, changes to IPLD.
-
-[Learn more](https://ipld.io/docs/intro/community/)

--- a/working-groups/libp2p-implementers-wg.md
+++ b/working-groups/libp2p-implementers-wg.md
@@ -1,7 +1,0 @@
-# libp2p Implementers Working Group
-
-Open-source community for maintainers and users of libp2p, the networking layer of IPFS.
-
-What's covered: Community events, roadmap, new features, triage, and performance issues.
-
-[Attend a meeting](https://calendar.google.com/calendar/u/0/embed?src=libp2p.io_0q9682i3te7eanhe9q7ae1c58g@group.calendar.google.com)


### PR DESCRIPTION
- added info where i could find it for more groups
- deleted the directory of files to minimize maintenance surface, move all content to the readme
- indent summaries of each group
- impose old-school web1 style link-nav and use github handles to tag conveners